### PR TITLE
fix: error with ssl config database

### DIFF
--- a/api/src/config/database.js
+++ b/api/src/config/database.js
@@ -13,12 +13,15 @@ module.exports = {
   host: DB_HOSTNAME,
   port: Number(DB_PORT),
   dialect: "postgres",
-  // dialectOptions: {
-  //   ssl: {
-  // require: true,
-  //     rejectUnauthorized: false,
-  //   },
-  // },
+  dialectOptions:
+    process.env.NODE_ENV === "production"
+      ? {
+          ssl: {
+            require: true,
+            rejectUnauthorized: false,
+          },
+        }
+      : {},
   define: {
     timestamps: true,
     underscored: true,


### PR DESCRIPTION
This pull request updates the database configuration to dynamically enable SSL settings based on the environment. The most important change involves modifying the `dialectOptions` to conditionally apply SSL settings when the application is running in production.

Database configuration changes:

* [`api/src/config/database.js`](diffhunk://#diff-5dc808bacdf6c48dbb50927e5b4dee3dab25d590b12dea0e58249af47e8e90c9L16-R24): Updated the `dialectOptions` to enable SSL with `require` set to `true` and `rejectUnauthorized` set to `false` only when `NODE_ENV` is set to `"production"`. For non-production environments, `dialectOptions` is set to an empty object.